### PR TITLE
Fix Chrome installation in Dockerfile for Railway deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     unzip \
     curl \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable \
+    ca-certificates \
+    && wget -q -O /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+    && apt-get install -y /tmp/google-chrome-stable_current_amd64.deb \
+    && rm /tmp/google-chrome-stable_current_amd64.deb \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies


### PR DESCRIPTION
- Replace deprecated apt-key method with direct .deb installation
- Download Chrome directly from Google's official URL
- Fixes exit code 127 build error on Railway