### PR TITLE
Switch from pipenv to requirements.txt for Railway deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 
@@ -14,13 +14,12 @@ RUN apt-get update && apt-get install -y \
     && rm /tmp/google-chrome-stable_current_amd64.deb \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
-COPY Pipfile* ./
-RUN pip install --no-cache-dir pipenv && \
-    pipenv install --system --deploy
-
-# Copy application files
+# Copy application files first
 COPY . .
+
+# Install Python dependencies from requirements.txt
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
 
 # Create .streamlit directory for config
 RUN mkdir -p .streamlit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,78 @@
+-i https://pypi.org/simple
+altair==6.0.0; python_version >= '3.9'
+async-generator==1.10; python_version >= '3.5'
+attrs==25.4.0; python_version >= '3.9'
+beautifulsoup4==4.14.3; python_full_version >= '3.7.0'
+blinker==1.9.0; python_version >= '3.9'
+cachetools==6.2.6; python_version >= '3.9'
+certifi==2026.1.4; python_version >= '3.7'
+charset-normalizer==3.4.4; python_version >= '3.7'
+click==8.3.1; python_version >= '3.10'
+flask==3.1.2; python_version >= '3.9'
+gitdb==4.0.12; python_version >= '3.7'
+gitpython==3.1.46; python_version >= '3.7'
+h11==0.16.0; python_version >= '3.8'
+idna==3.11; python_version >= '3.8'
+importlib-metadata==8.7.1; python_version >= '3.9'
+itsdangerous==2.2.0; python_version >= '3.8'
+jinja2==3.1.6; python_version >= '3.7'
+jsonschema==4.26.0; python_version >= '3.10'
+jsonschema-specifications==2025.9.1; python_version >= '3.9'
+markupsafe==3.0.3; python_version >= '3.9'
+mouseinfo==0.1.3
+mypy-extensions==1.1.0; python_version >= '3.8'
+narwhals==2.15.0; python_version >= '3.9'
+numpy==2.4.1; python_version >= '3.11'
+outcome==1.3.0.post0; python_version >= '3.7'
+packaging==26.0; python_version >= '3.8'
+pandas==2.3.3; python_version >= '3.9'
+pillow==12.1.0; python_version >= '3.10'
+plotly==6.5.2; python_version >= '3.8'
+protobuf==6.33.5; python_version >= '3.9'
+psycopg2-binary==2.9.11; python_version >= '3.9'
+pyarrow==23.0.0; python_version >= '3.10'
+pyautogui==0.9.54
+pydeck==0.9.1; python_version >= '3.8'
+pygetwindow==0.0.9
+pymsgbox==2.0.1; python_version >= '3.4'
+pyobjc-core==12.1; python_version >= '3.10'
+pyobjc-framework-cocoa==12.1; python_version >= '3.10'
+pyobjc-framework-quartz==12.1; python_version >= '3.10'
+pyperclip==1.11.0
+pyrect==0.2.0
+pyscreeze==1.0.1
+pysocks==1.7.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+python-dateutil==2.9.0.post0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
+python-dotenv==1.2.1; python_version >= '3.9'
+pytweening==1.2.0
+pytz==2025.2
+pywhatkit==5.4
+referencing==0.37.0; python_version >= '3.10'
+requests==2.32.5; python_version >= '3.9'
+rpds-py==0.30.0; python_version >= '3.10'
+rubicon-objc==0.5.3; python_version >= '3.10'
+schedule==1.2.2; python_version >= '3.7'
+selenium==4.40.0; python_version >= '3.10'
+six==1.17.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
+smmap==5.0.2; python_version >= '3.7'
+sniffio==1.3.1; python_version >= '3.7'
+sortedcontainers==2.4.0
+soupsieve==2.8.3; python_version >= '3.9'
+streamlit==1.53.1; python_version >= '3.10'
+tenacity==9.1.2; python_version >= '3.9'
+toml==0.10.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
+tornado==6.5.4; python_version >= '3.9'
+trio==0.32.0; python_version >= '3.10'
+trio-typing==0.10.0
+trio-websocket==0.12.2; python_version >= '3.8'
+types-certifi==2021.10.8.3
+types-urllib3==1.26.25.14
+typing-extensions==4.15.0; python_version >= '3.9'
+tzdata==2025.3; python_version >= '2'
+urllib3[socks]==2.6.3; python_version >= '3.9'
+webdriver-manager==4.0.2; python_version >= '3.7'
+websocket-client==1.9.0; python_version >= '3.9'
+werkzeug==3.1.5; python_version >= '3.9'
+wikipedia==1.4.0
+wsproto==1.3.2; python_version >= '3.10'
+zipp==3.23.0; python_version >= '3.9'


### PR DESCRIPTION
- Generate requirements.txt from Pipfile.lock for reliable Docker builds
- Use pip directly instead of pipenv (more stable for containerized deployments)
- Upgrade to Python 3.11 to match package requirements
- Fixes streamlit executable not found error